### PR TITLE
Enhance annotation selection indicators and handles

### DIFF
--- a/src/Slapon.Core/Models/ArrowAnnotation.cs
+++ b/src/Slapon.Core/Models/ArrowAnnotation.cs
@@ -49,6 +49,9 @@ public class ArrowAnnotation : BaseAnnotation
         g.DrawLine(pen, _start, _end);
         
         arrowHead.Dispose();
+
+        // Draw selection indicators if selected (using base class method for consistency)
+        DrawLineSelectionIndicators(g, _start, _end);
     }
 
     public override bool Contains(PointF point)

--- a/src/Slapon.Core/Models/BaseAnnotation.cs
+++ b/src/Slapon.Core/Models/BaseAnnotation.cs
@@ -4,8 +4,6 @@ using Slapon.Core.Interfaces;
 using Slapon.Core.Models;
 using Slapon.Core.Services;
 using System.Drawing.Imaging;
-using System.Drawing;
-using System.Drawing.Drawing2D;
 
 namespace Slapon.Core.Models;
 
@@ -67,6 +65,87 @@ public abstract class BaseAnnotation : IAnnotation
         );
     }
 
+    /// <summary>
+    /// Draws selection indicators around the annotation when it's selected
+    /// </summary>
+    protected virtual void DrawSelectionIndicators(Graphics g)
+    {
+        if (!IsSelected) return;
 
+        // Selection border - make it more visually distinct by inflating more and using a thicker line
+        using var selectionPen = new Pen(Color.FromArgb(100, 181, 246), 2f) { DashStyle = DashStyle.Dash };
+        var selectionRect = Rectangle.Round(Bounds);
+        selectionRect.Inflate(6, 6); // Increased from 4 to 6 for better visibility
+        g.DrawRectangle(selectionPen, selectionRect);
 
+        // Resize handles
+        DrawResizeHandles(g, selectionRect);
+    }
+
+    /// <summary>
+    /// Draws resize handles at the corners of the selection rectangle
+    /// </summary>
+    protected virtual void DrawResizeHandles(Graphics g, Rectangle bounds)
+    {
+        const int handleSize = 8; // Increased from 6 to 8 for better visibility
+        var handleColor = Color.FromArgb(100, 181, 246);
+        
+        using var brush = new SolidBrush(handleColor);
+        using var pen = new Pen(Color.White, 1);
+
+        var handles = new[]
+        {
+            new Point(bounds.Left - handleSize/2, bounds.Top - handleSize/2),
+            new Point(bounds.Right - handleSize/2, bounds.Top - handleSize/2),
+            new Point(bounds.Right - handleSize/2, bounds.Bottom - handleSize/2),
+            new Point(bounds.Left - handleSize/2, bounds.Bottom - handleSize/2)
+        };
+
+        foreach (var handle in handles)
+        {
+            var handleRect = new Rectangle(handle, new Size(handleSize, handleSize));
+            g.FillEllipse(brush, handleRect);
+            g.DrawEllipse(pen, handleRect);
+        }
+    }
+
+    /// <summary>
+    /// Draws selection indicators for line-based annotations (lines and arrows)
+    /// </summary>
+    protected virtual void DrawLineSelectionIndicators(Graphics g, Point start, Point end)
+    {
+        if (!IsSelected) return;
+
+        // Draw a wider selection outline around the line for better visibility
+        using var selectionPen = new Pen(Color.FromArgb(100, 181, 246), 5f) { DashStyle = DashStyle.Dash };
+        g.DrawLine(selectionPen, start, end);
+
+        // End point handles - make them larger and more visible
+        DrawLineEndHandles(g, start, end);
+    }
+
+    /// <summary>
+    /// Draws handles at the start and end points of a line
+    /// </summary>
+    protected virtual void DrawLineEndHandles(Graphics g, Point start, Point end)
+    {
+        const int handleSize = 10; // Increased from 8 to 10 for better visibility
+        var handleColor = Color.FromArgb(100, 181, 246);
+        
+        using var brush = new SolidBrush(handleColor);
+        using var pen = new Pen(Color.White, 1);
+
+        var handles = new[] { start, end };
+
+        foreach (var handle in handles)
+        {
+            var handleRect = new Rectangle(
+                handle.X - handleSize/2, 
+                handle.Y - handleSize/2, 
+                handleSize, 
+                handleSize);
+            g.FillEllipse(brush, handleRect);
+            g.DrawEllipse(pen, handleRect);
+        }
+    }
 }

--- a/src/Slapon.Core/Models/BlurAnnotation.cs
+++ b/src/Slapon.Core/Models/BlurAnnotation.cs
@@ -52,7 +52,7 @@ public class BlurAnnotation : BaseAnnotation
         g.DrawRectangle(borderPen, blurRect);
     }
 
-    private void DrawSelectionIndicators(Graphics g)
+    private new void DrawSelectionIndicators(Graphics g)
     {
         // Selection border
         using var selectionPen = new Pen(Color.FromArgb(100, 181, 246), 1f) { DashStyle = DashStyle.Dash };
@@ -64,7 +64,7 @@ public class BlurAnnotation : BaseAnnotation
         DrawResizeHandles(g, selectionRect);
     }
 
-    private void DrawResizeHandles(Graphics g, Rectangle bounds)
+    private new void DrawResizeHandles(Graphics g, Rectangle bounds)
     {
         const int handleSize = 8;
         var handleColor = Color.FromArgb(100, 181, 246);

--- a/src/Slapon.Core/Models/HighlightAnnotation.cs
+++ b/src/Slapon.Core/Models/HighlightAnnotation.cs
@@ -19,6 +19,9 @@ public class HighlightAnnotation : BaseAnnotation
         {
             g.FillRectangle(highlightBrush, Bounds);
         }
+
+        // Draw selection indicators if selected
+        DrawSelectionIndicators(g);
     }
 
     public override bool Contains(PointF point)

--- a/src/Slapon.Core/Models/LineAnnotation.cs
+++ b/src/Slapon.Core/Models/LineAnnotation.cs
@@ -33,6 +33,9 @@ public class LineAnnotation : BaseAnnotation
     {
         using var pen = new Pen(GetTransparentColor(), LineThickness);
         g.DrawLine(pen, _start, _end);
+
+        // Draw selection indicators if selected (using base class method for consistency)
+        DrawLineSelectionIndicators(g, _start, _end);
     }
 
     public override bool Contains(PointF point)

--- a/src/Slapon.Core/Models/RectangleAnnotation.cs
+++ b/src/Slapon.Core/Models/RectangleAnnotation.cs
@@ -25,6 +25,9 @@ public class RectangleAnnotation : BaseAnnotation
         {
             g.DrawRectangle(pen, Bounds.X, Bounds.Y, Bounds.Width, Bounds.Height);
         }
+
+        // Draw selection indicators if selected (using base class method for consistency)
+        DrawSelectionIndicators(g);
     }
 
     public override bool Contains(PointF point)

--- a/src/Slapon.Core/Models/TextAnnotation.cs
+++ b/src/Slapon.Core/Models/TextAnnotation.cs
@@ -120,7 +120,7 @@ public class TextAnnotation : BaseAnnotation
         }
     }
 
-    private void DrawResizeHandles(Graphics g, Rectangle bounds)
+    private new void DrawResizeHandles(Graphics g, Rectangle bounds)
     {
         const int handleSize = 6;
         var handleColor = Color.FromArgb(100, 181, 246);


### PR DESCRIPTION
Enhance annotation selection indicators and handles

- Added `DrawLineSelectionIndicators` to `ArrowAnnotation` for improved selection feedback.
- Updated `BaseAnnotation` with new virtual methods for drawing selection indicators and resize handles.
- Modified `BlurAnnotation`, `HighlightAnnotation`, `LineAnnotation`, `RectangleAnnotation`, and `TextAnnotation` to use new methods from `BaseAnnotation`.
- Introduced `DrawLineSelectionIndicators` and `DrawLineEndHandles` for line-based annotations.
- Removed redundant `using System.Drawing` directive in `BaseAnnotation.cs`.
- Changed `DrawSelectionIndicators` and `DrawResizeHandles` in `BlurAnnotation` and `TextAnnotation` to `private new` to hide base implementations.